### PR TITLE
Follow PR number links in commits, add output author option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Options:
                                for the changelog                      [required]
   --output-pr-links, --opl     Adds the corresponding Github link at the end of
                                the change message
+  --output-author, --oa        Appends the PR author to the change message
   --prev-version, --pv         The prev version to generate the
                                changelog from.
                                - If arg is a valid Semver string

--- a/src/generateChangelog.js
+++ b/src/generateChangelog.js
@@ -111,9 +111,9 @@ async function main(args) {
     process.exit(1);
   }
 
-  let releaseTags = [args.nextVersion].concat(
-    Array.from(new Set(releases.map(release => release.name)))
-  );
+  const releaseSet = new Set(releases.map(release => release.name));
+  releaseSet.add(args.nextVersion);
+  let releaseTags = Array.from(releaseSet);
 
   if (isValidSemVer(args.prevVersion)) {
     releaseTags = releaseTags.filter(name =>
@@ -140,9 +140,17 @@ async function main(args) {
       thisRelease,
       repoInfo
     );
+    const matchPR = (pr, commit) => {
+      if (pr.sha === commit.sha) return true;
+      const nrMatch = commit.commit.message.match(/.*\(\#(.*)\)/);
+      if (nrMatch && nrMatch[1]) {
+        return parseInt(nrMatch[1]) === pr.number;
+      }
+      return false;
+    };
     const commitsToPrs = commits
       .map(commit => {
-        return prs.find(pr => pr.sha === commit.sha);
+        return prs.find(pr => matchPR(pr, commit));
       })
       .filter(_ => _);
     if (commitsToPrs.length !== 0) {

--- a/src/generateChangelog.js
+++ b/src/generateChangelog.js
@@ -150,11 +150,24 @@ async function main(args) {
     };
     const commitsToPrs = commits
       .map(commit => {
-        return prs.find(pr => matchPR(pr, commit));
+        const pr = prs.find(pr => matchPR(pr, commit));
+        return pr
+          ? {
+              ...pr,
+              author:
+                commit && commit.author ? commit.author.login : "No Author"
+            }
+          : undefined;
       })
       .filter(_ => _);
     if (commitsToPrs.length !== 0) {
-      buildOutput(commitsToPrs, value, repoInfo, args.outputPrLinks);
+      buildOutput(
+        commitsToPrs,
+        value,
+        repoInfo,
+        args.outputPrLinks,
+        args.outputAuthor
+      );
     }
   }
 }

--- a/src/helpers/changelog.js
+++ b/src/helpers/changelog.js
@@ -24,7 +24,13 @@ export const extractIssuesFromString = str => {
 };
 
 const newLine = "\n";
-export const buildOutput = (logs, header, repoInfo, outputPrLinks) => {
+export const buildOutput = (
+  logs,
+  header,
+  repoInfo,
+  outputPrLinks,
+  outputAuthor
+) => {
   let out = `\n## ${header}\n`;
 
   logs.forEach(_ => {
@@ -32,9 +38,14 @@ export const buildOutput = (logs, header, repoInfo, outputPrLinks) => {
       ? newLine +
         `- ${_.message} PR: [\#${_.number}](https://github.com/${
           repoInfo.owner
-        }/${repoInfo.repo}/pull/${_.number}) ${_.issues}`.trim() +
-        newLine
-      : newLine + `- ${_.message} ${_.issues}`.trim() + newLine;
+        }/${repoInfo.repo}/pull/${_.number}) ${_.issues}`.trim()
+      : newLine + `- ${_.message} ${_.issues}`.trim();
+
+    if (outputAuthor) {
+      out += ` (${_.author})`;
+    }
+
+    out += newLine;
   });
   console.log(out);
 };

--- a/src/helpers/cli.js
+++ b/src/helpers/cli.js
@@ -63,6 +63,10 @@ const commandLineSetUp = y =>
         describe:
           "Adds the corresponding Github link at the end of the change message"
       },
+      "output-author": {
+        alias: "oa",
+        describe: "Adds the author of the PR to the changelog message"
+      },
       "prev-version": {
         alias: "pv",
         describe: `The prev version to generate the changelog from.

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -3,12 +3,14 @@ import semverCompare from "semver-compare";
 
 export const versionFilter = (name, prevVersion, nextVersion) => {
   const tokenizedNextVersion = nextVersion.split(".");
-  return prevVersion
+  const afterPrevVersion = prevVersion
     ? semverCompare(name, prevVersion) >= 0
     : name.startsWith(
         prevVersion ||
           [tokenizedNextVersion[0], tokenizedNextVersion[1]].join(".")
       );
+  const beforeNextVersion = semverCompare(name, nextVersion) <= 0;
+  return afterPrevVersion && beforeNextVersion;
 };
 
 export const isValidSemVer = str => semver.valid(str);

--- a/src/helpers/utils.test.js
+++ b/src/helpers/utils.test.js
@@ -32,6 +32,12 @@ test("versionFilter filters correctly", () => {
       prevVersion: "2.1.1",
       nextVersion: "2.1.5",
       expect: false
+    },
+    {
+      tagName: "2.1.0",
+      prevVersion: "1.9.1",
+      nextVersion: "2.0.0",
+      expect: false
     }
   ];
 


### PR DESCRIPTION
This PR adds some small tweaks useful for Bloom:

First, the capability to lookup the PR of a commit based on the PR number in the commit message, in case the commit SHA doesn't match the one stored in the PR (useful for cherry picked commits).

Then, I have also added an option called `output-author` that adds the author of the commit to the changelog line.
